### PR TITLE
Replaced all return NotImplemented calls

### DIFF
--- a/jlab_datascience_toolkit/core/jdst_analysis.py
+++ b/jlab_datascience_toolkit/core/jdst_analysis.py
@@ -8,4 +8,4 @@ class JDSTAnalysis(JDSTModule,ABC):
 
     # Run the analysis:
     def run(self):
-        return NotImplemented
+        raise NotImplementedError

--- a/jlab_datascience_toolkit/core/jdst_data_parser.py
+++ b/jlab_datascience_toolkit/core/jdst_data_parser.py
@@ -9,7 +9,7 @@ class JDSTDataParser(JDSTModule,ABC):
     
     # Load and save the data:
     def load_data(self):
-        return NotImplemented
+        raise NotImplementedError
     
     def save_data(self):
-        return NotImplemented
+        raise NotImplementedError

--- a/jlab_datascience_toolkit/core/jdst_data_prep.py
+++ b/jlab_datascience_toolkit/core/jdst_data_prep.py
@@ -11,12 +11,12 @@ class JDSTDataPrep(JDSTModule,ABC):
     # This might be helpful, if the underlying data preperation is a computational intensive operation
     # And we want to avoid calling it multiple times. Thus, we just store the data after preparation:
     def save_data(self):
-        return NotImplemented
+        raise NotImplementedError
     
     # Run the data preparation:
     def run(self):
-        return NotImplemented
+        raise NotImplementedError
 
     # Reverse the data preparation (if possible):
     def reverse(self):
-        return NotImplemented
+        raise NotImplementedError

--- a/jlab_datascience_toolkit/core/jdst_model.py
+++ b/jlab_datascience_toolkit/core/jdst_model.py
@@ -8,13 +8,13 @@ class JDSTModel(JDSTModule,ABC):
 
     # Train the model:
     def train(self):
-        return NotImplemented
+        raise NotImplementedError
 
     # Get a prediction:
     def predict(self):
-        return NotImplemented
+        raise NotImplementedError
     
     # Run a small analysis (e.g. determine ROC-Curve, MSE,...)
     def analysis(self):
-        return NotImplemented
+        raise NotImplementedError
     

--- a/jlab_datascience_toolkit/core/jdst_module.py
+++ b/jlab_datascience_toolkit/core/jdst_module.py
@@ -14,18 +14,18 @@ class JDSTModule(ABC):
     # Get module info: Just briefly describe what this module is doing, 
     # what are the inputs and what is returned?
     def get_info(self):
-        return NotImplemented
+        raise NotImplementedError
     
-    # Load and save configuration files which run  the module:
+    # Load and save configuration files which run the module:
     def load_config(self):
-        return NotImplemented
+        raise NotImplementedError
     
     def save_config(self):
-        return NotImplemented
+        raise NotImplementedError
     
     # Load and save for checkpointing (i.e. capture state of module)
     def load(self):
-        return NotImplemented
+        raise NotImplementedError
     
     def save(self):
-        return NotImplemented
+        raise NotImplementedError


### PR DESCRIPTION
Core ABCs now raise NotImplementedErrors when not defined by subclasses. Closes #11 