### PR TITLE
24 common csv parser

### DIFF
--- a/jlab_datascience_toolkit/data_parser/__init__.py
+++ b/jlab_datascience_toolkit/data_parser/__init__.py
@@ -11,3 +11,8 @@ register(
     id="PandasParser_v0",
     entry_point="jlab_datascience_toolkit.data_parser.pandas_parser_v0:PandasParser"
 )
+
+register(
+    id='CSVParser_v0',
+    entry_point="jlab_datascience_toolkit.data_parser.csv_parser_v0:CSVParser"
+)

--- a/jlab_datascience_toolkit/data_parser/csv_parser_v0.py
+++ b/jlab_datascience_toolkit/data_parser/csv_parser_v0.py
@@ -10,7 +10,7 @@ import os
 parser_log = logging.getLogger('CSVParser Logger')
 
 class CSVParser(JDSTDataParser):
-    """Reads a list of CSV files and concatenates them in a CSV DataFrame.
+    """Reads a list of CSV files and concatenates them in a Pandas DataFrame.
 
     Intialization arguments: 
         `config: dict`

--- a/jlab_datascience_toolkit/data_parser/csv_parser_v0.py
+++ b/jlab_datascience_toolkit/data_parser/csv_parser_v0.py
@@ -1,0 +1,128 @@
+from jlab_datascience_toolkit.core.jdst_data_parser import JDSTDataParser
+import jlab_datascience_toolkit.utils.parser_utilities as utils
+from pathlib import Path
+import pandas as pd
+import logging
+import yaml
+import inspect
+import os
+
+parser_log = logging.getLogger('CSVParser Logger')
+
+class CSVParser(JDSTDataParser):
+    """Reads a list of CSV files and concatenates them in a CSV DataFrame.
+
+    Intialization arguments: 
+        `config: dict`
+
+    Optional configuration keys: 
+        `filepaths: str | list[str]`
+            Paths to files the module should parse. Defaults to `[]` which 
+            produces a warning when load_data() is called.
+        `read_kwargs: dict = {}`
+            Arguments to be passed 
+        `concat_kwargs: dict = {}`
+
+    Attributes
+    ----------
+    name : str
+        Name of the module
+    config: dict
+        Configuration information
+
+    Methods
+    -------
+    get_info()
+        Prints this docstring
+    load(path)
+        Loads this module from `path`
+    save(path)
+        Saves this module to `path`
+    load_data(path)
+        Loads all files listed in `config['filepaths']` and concatenates them
+    save_data(path)
+        Does nothing
+    load_config(path)
+        Calls load(path)
+    save_config(path)
+        Calls save(path)
+
+    """
+
+    def __init__(self, config: dict = None):
+        # It is important not to use default mutable arguments in python
+        #   (lists/dictionaries), so we set config to None and update later
+
+        # Set default config
+        self.config = dict(
+            filepaths=[], 
+            read_kwargs = {},
+            concat_kwargs = {},
+        )
+        # Update configuration with new configuration
+        if config is not None:
+            self.config.update(config)
+
+        # To handle strings and lists of strings, we convert the former here
+        if isinstance(self.config['filepaths'], str):
+            self.config['filepaths'] = [self.config['filepaths']]
+
+    @property
+    def name(self):
+        return 'CSVParser_v0'
+
+    def get_info(self):
+        """ Prints the docstring for the CSVParser module"""
+        print(inspect.getdoc(self))
+
+    def load(self, path: str):
+        """ Load the entire module state from `path`
+
+        Args:
+            path (str): Path to folder containing module files.
+        """
+        self.config.update(utils.load_yaml_config(path))
+
+    def save(self, path: str):
+        """Save the entire module state to a folder at `path`
+
+        Args:
+            path (str): Location to save the module folder
+        """
+        utils.save_config_to_yaml(self.config, path)
+
+    def load_data(self) -> pd.DataFrame:
+        """ Loads all files listed in `config['filepaths']` 
+        read_kwargs are passed to the appropriate pd.read_{file_format} function
+        concat_kwargs are passed to pd.concat() after all files are read
+
+        Returns:
+            pd.DataFrame: A single DataFrame containing concatenated data
+        """
+        data_list = utils.read_data_to_pandas(
+            filepaths=self.config['filepaths'],
+            file_format='csv',
+            **self.config['read_kwargs']
+        )
+
+
+        # Check for empty data and return nothing if empty
+        if not data_list:
+            parser_log.warning(
+                'load_data() returning None. This is probably not what you '
+                'wanted. Ensure that your configuration includes the key '
+                '"filepaths"')
+            return 
+        
+        return pd.concat(data_list, **self.config['concat_kwargs'])
+        
+    def load_config(self, path: str):
+        parser_log.debug('Calling load()...')
+        return self.load(path)
+
+    def save_config(self, path: str):
+        parser_log.debug('Calling save()...')
+        return self.save(path)
+    
+    def save_data(self):
+        return super().save_data()

--- a/jlab_datascience_toolkit/utils/parser_utilities.py
+++ b/jlab_datascience_toolkit/utils/parser_utilities.py
@@ -15,14 +15,6 @@ def load_yaml_config(path):
         config = yaml.safe_load(f)
     return config
 
-# Supported file formats
-read_functions = dict(
-    csv=pd.read_csv,
-    feather=pd.read_feather,
-    json=pd.read_json,
-    pickle=pd.read_pickle
-)
-
 def read_data_to_pandas(filepaths: list, file_format: str, **kwargs) -> pd.DataFrame:
         """ Loads all files listed in filepaths and reads them.
         All kwargs other than filepaths and file_format will be passed to the read_function
@@ -31,6 +23,15 @@ def read_data_to_pandas(filepaths: list, file_format: str, **kwargs) -> pd.DataF
         Returns:
             pd.DataFrame: A single DataFrame containing list of dataframes
         """
+
+        # Supported file formats
+        read_functions = dict(
+            csv=pd.read_csv,
+            feather=pd.read_feather,
+            json=pd.read_json,
+            pickle=pd.read_pickle
+        )
+
         data_list = []
         read_function = read_functions[file_format]
         for file in filepaths:

--- a/jlab_datascience_toolkit/utils/parser_utilities.py
+++ b/jlab_datascience_toolkit/utils/parser_utilities.py
@@ -1,0 +1,40 @@
+import os
+import pathlib
+import yaml
+import pandas as pd
+
+def save_config_to_yaml(config, path):
+    save_path = pathlib.Path(path)
+    os.makedirs(save_path)
+    with open(save_path.joinpath('config.yaml'), 'w') as f:
+        yaml.safe_dump(self.config, f)
+
+def load_yaml_config(path):
+    base_path = Path(path)
+    with open(base_path.joinpath('config.yaml'), 'r') as f:
+        config = yaml.safe_load(f)
+    return config
+
+# Supported file formats
+read_functions = dict(
+    csv=pd.read_csv,
+    feather=pd.read_feather,
+    json=pd.read_json,
+    pickle=pd.read_pickle
+)
+
+def read_data_to_pandas(filepaths: list, file_format: str, **kwargs) -> pd.DataFrame:
+        """ Loads all files listed in filepaths and reads them.
+        All kwargs other than filepaths and file_format will be passed to the read_function
+        for its associated file_format
+
+        Returns:
+            pd.DataFrame: A single DataFrame containing list of dataframes
+        """
+        data_list = []
+        read_function = read_functions[file_format]
+        for file in filepaths:
+            data = read_function(file, **kwargs)
+            data_list.append(data)
+
+        return data_list

--- a/utests/utest_pandas_parser_v0.py
+++ b/utests/utest_pandas_parser_v0.py
@@ -6,6 +6,7 @@ import numpy as np
 import os
 
 rng = np.random.default_rng(seed=42)
+parser_id = 'PandasParser_v0'
 
 
 class TestPandasParserv0(unittest.TestCase):
@@ -64,14 +65,14 @@ class TestPandasParserv0(unittest.TestCase):
 
     def test_no_config(self):
         print('*****No Config Test*****\n')
-        parser = make('PandasParser_v0')
+        parser = make(parser_id)
         output = parser.load_data()
         self.assertIsNone(output)
 
     def test_string_filepaths(self):
         print('*****String Filepaths Test*****\n')
 
-        parser = make('PandasParser_v0', config=dict(filepaths=self.path))
+        parser = make(parser_id, config=dict(filepaths=self.path))
         output = parser.load_data()
         print('Output Head:\n', output.head())
 
@@ -80,14 +81,14 @@ class TestPandasParserv0(unittest.TestCase):
     def test_one_item_list_filepaths(self):
         print('*****One Item List Test*****\n')
 
-        parser = make('PandasParser_v0', config=dict(filepaths=[self.path]))
+        parser = make(parser_id, config=dict(filepaths=[self.path]))
         output = parser.load_data()
         print('Output Head:\n', output.head())
         self.assertEqual(output.shape, (self.samples, len(self.columns)+1))
 
     def test_two_filepaths(self):
         print('*****Two Filepaths Test*****\n')
-        parser = make('PandasParser_v0', config=dict(filepaths=[self.path, self.path2]))
+        parser = make(parser_id, config=dict(filepaths=[self.path, self.path2]))
         output = parser.load_data()
         print('Output Head:\n', output.head())
         print('Output shape:', output.shape)
@@ -97,7 +98,7 @@ class TestPandasParserv0(unittest.TestCase):
         print('*****Usecols Read Arg Test*****\n')
 
         two_columns = ['R121GMES', 'R121GSET']
-        parser = make('PandasParser_v0', config=dict(
+        parser = make(parser_id, config=dict(
             filepaths=self.path, read_kwargs=dict(usecols=two_columns)))
         output = parser.load_data()
         print('Output Head:\n', output.head())
@@ -110,7 +111,7 @@ class TestPandasParserv0(unittest.TestCase):
         def column_lambda(x): return ('GMES' in x) or (x == 'Date')
         read_kwargs = dict(usecols=column_lambda,
                            index_col='Date', parse_dates=True)
-        parser = make('PandasParser_v0',
+        parser = make(parser_id,
                       config=dict(
                           filepaths=self.path, read_kwargs=read_kwargs)
                       )


### PR DESCRIPTION
This pull request should close #24 and close #33. The implementation of CSVParser is essentially the PandasParser with the file_format field forced to 'csv'. 

Personally, I'm not too fond of this solution as it will require a different parser for every file format and will result in a large amount of code duplication. However, I don't see another way to address #24 and #33 since it's apparent the current solution is not acceptable....