### PR TITLE
18 implemention of drivers as a graph

### DIFF
--- a/jlab_datascience_toolkit/utils/graph_driver_utils.py
+++ b/jlab_datascience_toolkit/utils/graph_driver_utils.py
@@ -1,8 +1,5 @@
 from typing import NamedTuple, Union, Iterable
-from Hall_B.AIDAPT.registration import make 
-import Hall_B.AIDAPT.data_parsers
-import Hall_B.AIDAPT.data_prep
-import Hall_B.AIDAPT.models
+from jlab_datascience_toolkit.utils.registration import make 
     
 class GraphRuntime():
     class Edge(NamedTuple):
@@ -33,19 +30,20 @@ class GraphRuntime():
 
         return dict.fromkeys(distinct_data, None)
     
-    def get_module_dict(self, modules, config):
+    def get_module_dict(self, modules, config_kwargs_list):
         module_dict = dict.fromkeys(modules, None)
         for m_name in module_dict:
             module_id = modules[m_name]
             print(f'Making {m_name} with module ID: {module_id}')
-            module_dict[m_name] = make(module_id, config=config[m_name], name=m_name)
+            config_kwargs = config_kwargs_list[m_name]
+            module_dict[m_name] = make(module_id, **config_kwargs)
 
         return module_dict
     
-    def run_graph(self, graph, modules, config):
+    def run_graph(self, graph, modules, config_kwargs_list):
         graph_edges = self.tuples_to_edges(graph)
         data = self.get_distinct_data_dict(graph_edges)
-        module_dict = self.get_module_dict(modules, config)
+        module_dict = self.get_module_dict(modules, config_kwargs_list)
         for edge in graph_edges:
         
             if '.' in edge.function:

--- a/jlab_datascience_toolkit/utils/graph_driver_utils.py
+++ b/jlab_datascience_toolkit/utils/graph_driver_utils.py
@@ -1,0 +1,77 @@
+from typing import NamedTuple, Union, Iterable
+from Hall_B.AIDAPT.registration import make 
+import Hall_B.AIDAPT.data_parsers
+import Hall_B.AIDAPT.data_prep
+import Hall_B.AIDAPT.models
+    
+class GraphRuntime():
+    class Edge(NamedTuple):
+        input: Union[str, tuple]
+        function: str
+        output: Union[str, tuple]
+
+    def tuples_to_edges(self,tuple_list):
+        edges = []
+        for tuple in tuple_list:
+            edges.append(self.Edge(*tuple))
+
+        return edges
+    
+    def get_distinct_data_dict(self, graph_edges):
+        distinct_data = set()
+        for edge in graph_edges:
+            if edge.input is not None:
+                if isinstance(edge.input, str):
+                    distinct_data.add(edge.input)
+                else:
+                    [distinct_data.add(val) for val in edge.input]
+            if edge.output is not None:
+                if isinstance(edge.output, str):
+                    distinct_data.add(edge.output)
+                else:
+                    [distinct_data.add(val) for val in edge.output]
+
+        return dict.fromkeys(distinct_data, None)
+    
+    def get_module_dict(self, modules, config):
+        module_dict = dict.fromkeys(modules, None)
+        for m_name in module_dict:
+            module_id = modules[m_name]
+            print(f'Making {m_name} with module ID: {module_id}')
+            module_dict[m_name] = make(module_id, config=config[m_name], name=m_name)
+
+        return module_dict
+    
+    def run_graph(self, graph, modules, config):
+        graph_edges = self.tuples_to_edges(graph)
+        data = self.get_distinct_data_dict(graph_edges)
+        module_dict = self.get_module_dict(modules, config)
+        for edge in graph_edges:
+        
+            if '.' in edge.function:
+                m_name, fn_call = edge.function.split('.')
+                fn = getattr(module_dict[m_name], fn_call)
+            else:
+                fn = getattr(self, edge.function)
+
+            if edge.input is None:
+                fn_in = [] #Unpacks to 0 arguments
+            elif isinstance(edge.input, str):
+                fn_in = [data[edge.input]] # Unpacks to 1 argument
+            elif isinstance(edge.input, Iterable):
+                fn_in = [data[val] for val in edge.input]
+            
+            # Take advantage of list unpacking for arguments
+            out = fn(*fn_in)
+
+            if out is not None:
+                if isinstance(edge.output, tuple):
+                    for o, d in zip(out, edge.output):
+                        data[d] = o
+                else:
+                    data[edge.output] = out
+
+        return data, module_dict
+
+    def combine(self, *inputs):
+        return inputs


### PR DESCRIPTION
This pull request adds a single "graph driver" to the core repository since a version of it has been floating around in a number of projects. 

I've tried to make it a bit more generic than the version that was floating around so that it can work well with existing users and improve ease of use for new ones. Specifically, this version changes the `make()` call so that it can work with arbitrary keyword arguments. 

I'd be happy to work with anyone that is using a version of this code in order to migrate from their current code to the version in this pull request. I believe that any changes should be minimal, but I haven't tested migrating anyone's code yet. 

Closes #18.