### PR TITLE
63 add graph driver example

### DIFF
--- a/jlab_datascience_toolkit/__init__.py
+++ b/jlab_datascience_toolkit/__init__.py
@@ -1,0 +1,5 @@
+import jlab_datascience_toolkit.data_parsers 
+import jlab_datascience_toolkit.data_preps 
+import jlab_datascience_toolkit.models 
+import jlab_datascience_toolkit.trainers
+import jlab_datascience_toolkit.analyses

--- a/jlab_datascience_toolkit/analyses/multiclass_analysis_v0.py
+++ b/jlab_datascience_toolkit/analyses/multiclass_analysis_v0.py
@@ -17,6 +17,10 @@ class Analysis:
         sample_weight: np.ndarray = None,
         logdir: str = None,
     ) -> list:
+        if "logdir" in self.configs:
+            if logdir is None:
+                logdir = self.configs["logdir"]
+
         if logdir is not None:
             os.makedirs(logdir, exist_ok=True)
         ans = []

--- a/jlab_datascience_toolkit/cfgs/defaults/multiclass_graph_cfg.yaml
+++ b/jlab_datascience_toolkit/cfgs/defaults/multiclass_graph_cfg.yaml
@@ -1,0 +1,207 @@
+graph: 
+  - - null
+    - parser.load_data
+    - df
+  - - df
+    - map_species
+    - [df, labels, target_names]
+  - - df
+    - prep.run
+    - [x_train, x_val, x_test, y_train, y_val, y_test]
+  - - x_train
+    - scaler.fit_transform
+    - x_train
+  - - x_val
+    - scaler.transform
+    - x_val
+  - - x_test
+    - scaler.transform
+    - x_test
+  - - [x_val, y_val]
+    - combine
+    - validation_data
+  - - [module.model, x_train, y_train, validation_data]
+    - trainer.fit
+    - history
+  - - x_test
+    - model.predict
+    - y_pred
+  - - y_pred
+    - argmax
+    - y_pred
+  - - [y_test, y_pred, labels, target_names]
+    - analysis.run
+    - results
+  - - results
+    - print
+    - null
+modules: 
+  parser: FamousDatasets_v0
+  prep: SplitDataFrame_v0
+  model: KerasMLP_v0
+  trainer: KerasTrainer_v0
+  analysis: MultiClassClassificationAnalysis_v0
+  scaler: SKLearnStandardScaler
+kwargs_list: 
+  scaler: {}
+  parser: 
+    configs:
+      registered_name: FamousDatasets_v0
+      dataset_name: iris
+  prep: 
+    configs:
+      feature_columns:
+      - sepal_length
+      - sepal_width
+      - petal_length
+      - petal_width
+      registered_name: SplitDataFrame_v0
+      rows_fractions:
+      - 0.7
+      - 0.15
+      - 0.15
+      target_columns: species_int
+  model:
+    configs:
+      input_dim: 4
+      layers_dicts:
+      - layer_configs:
+          activation: relu
+          units: 10
+        layer_type: Dense
+      - layer_type: BatchNormalization
+      - layer_configs:
+          rate: 0.05
+        layer_type: Dropout
+      - layer_configs:
+          activation: relu
+          units: 20
+        layer_type: Dense
+      - layer_type: BatchNormalization
+      - layer_configs:
+          rate: 0.05
+        layer_type: Dropout
+      - layer_configs:
+          activation: relu
+          units: 10
+        layer_type: Dense
+      - layer_type: BatchNormalization
+      - layer_configs:
+          rate: 0.05
+        layer_type: Dropout
+      - layer_configs:
+          activation: relu
+          units: 5
+        layer_type: Dense
+      - layer_type: BatchNormalization
+      - layer_configs:
+          activation: softmax
+          units: 3
+        layer_type: Dense
+      registered_name: KerasMLP_v0
+  trainer:
+    configs:
+      callbacks:
+      - callback_type: EarlyStopping
+        monitor: val_loss
+        patience: 50
+      - callback_type: ReduceLROnPlateau
+        monitor: val_loss
+        patience: 10
+      epochs: 400
+      loss_configs:
+        loss_type: SparseCategoricalCrossentropy
+      optimizer_configs:
+        learning_rate: 0.01
+        optimizer_type: Adam
+      registered_name: KerasTrainer_v0
+  analysis:
+    configs:
+      registered_name: MultiClassClassificationAnalysis_v0
+      submodules:
+      - type: confusion_matrix
+      - configs:
+          normalize: true
+        type: accuracy_score
+      - type: classification_report
+        configs:
+          output_dict: true
+  
+analysis_configs:
+  registered_name: MultiClassClassificationAnalysis_v0
+  submodules:
+  - type: confusion_matrix
+  - configs:
+      normalize: true
+    type: accuracy_score
+  - type: classification_report
+    configs:
+      output_dict: true
+model_configs:
+  input_dim: 4
+  layers_dicts:
+  - layer_configs:
+      activation: relu
+      units: 10
+    layer_type: Dense
+  - layer_type: BatchNormalization
+  - layer_configs:
+      rate: 0.05
+    layer_type: Dropout
+  - layer_configs:
+      activation: relu
+      units: 20
+    layer_type: Dense
+  - layer_type: BatchNormalization
+  - layer_configs:
+      rate: 0.05
+    layer_type: Dropout
+  - layer_configs:
+      activation: relu
+      units: 10
+    layer_type: Dense
+  - layer_type: BatchNormalization
+  - layer_configs:
+      rate: 0.05
+    layer_type: Dropout
+  - layer_configs:
+      activation: relu
+      units: 5
+    layer_type: Dense
+  - layer_type: BatchNormalization
+  - layer_configs:
+      activation: softmax
+      units: 3
+    layer_type: Dense
+  registered_name: KerasMLP_v0
+parser_configs:
+  registered_name: FamousDatasets_v0
+  dataset_name: iris
+prep_configs:
+  feature_columns:
+  - sepal_length
+  - sepal_width
+  - petal_length
+  - petal_width
+  registered_name: SplitDataFrame_v0
+  rows_fractions:
+  - 0.7
+  - 0.15
+  - 0.15
+  target_columns: species_int
+trainer_configs:
+  callbacks:
+  - callback_type: EarlyStopping
+    monitor: val_loss
+    patience: 50
+  - callback_type: ReduceLROnPlateau
+    monitor: val_loss
+    patience: 10
+  epochs: 400
+  loss_configs:
+    loss_type: SparseCategoricalCrossentropy
+  optimizer_configs:
+    learning_rate: 0.01
+    optimizer_type: Adam
+  registered_name: KerasTrainer_v0
+logdir: null

--- a/jlab_datascience_toolkit/cfgs/defaults/multiclass_graph_cfg.yaml
+++ b/jlab_datascience_toolkit/cfgs/defaults/multiclass_graph_cfg.yaml
@@ -1,3 +1,4 @@
+logdir: ${hydra:runtime.output_dir}
 graph: 
   - - null
     - parser.load_data
@@ -101,6 +102,7 @@ kwargs_list:
       registered_name: KerasMLP_v0
   trainer:
     configs:
+      logdir: ${logdir}
       callbacks:
       - callback_type: EarlyStopping
         monitor: val_loss
@@ -117,6 +119,7 @@ kwargs_list:
       registered_name: KerasTrainer_v0
   analysis:
     configs:
+      logdir: ${logdir}
       registered_name: MultiClassClassificationAnalysis_v0
       submodules:
       - type: confusion_matrix
@@ -126,82 +129,4 @@ kwargs_list:
       - type: classification_report
         configs:
           output_dict: true
-  
-analysis_configs:
-  registered_name: MultiClassClassificationAnalysis_v0
-  submodules:
-  - type: confusion_matrix
-  - configs:
-      normalize: true
-    type: accuracy_score
-  - type: classification_report
-    configs:
-      output_dict: true
-model_configs:
-  input_dim: 4
-  layers_dicts:
-  - layer_configs:
-      activation: relu
-      units: 10
-    layer_type: Dense
-  - layer_type: BatchNormalization
-  - layer_configs:
-      rate: 0.05
-    layer_type: Dropout
-  - layer_configs:
-      activation: relu
-      units: 20
-    layer_type: Dense
-  - layer_type: BatchNormalization
-  - layer_configs:
-      rate: 0.05
-    layer_type: Dropout
-  - layer_configs:
-      activation: relu
-      units: 10
-    layer_type: Dense
-  - layer_type: BatchNormalization
-  - layer_configs:
-      rate: 0.05
-    layer_type: Dropout
-  - layer_configs:
-      activation: relu
-      units: 5
-    layer_type: Dense
-  - layer_type: BatchNormalization
-  - layer_configs:
-      activation: softmax
-      units: 3
-    layer_type: Dense
-  registered_name: KerasMLP_v0
-parser_configs:
-  registered_name: FamousDatasets_v0
-  dataset_name: iris
-prep_configs:
-  feature_columns:
-  - sepal_length
-  - sepal_width
-  - petal_length
-  - petal_width
-  registered_name: SplitDataFrame_v0
-  rows_fractions:
-  - 0.7
-  - 0.15
-  - 0.15
-  target_columns: species_int
-trainer_configs:
-  callbacks:
-  - callback_type: EarlyStopping
-    monitor: val_loss
-    patience: 50
-  - callback_type: ReduceLROnPlateau
-    monitor: val_loss
-    patience: 10
-  epochs: 400
-  loss_configs:
-    loss_type: SparseCategoricalCrossentropy
-  optimizer_configs:
-    learning_rate: 0.01
-    optimizer_type: Adam
-  registered_name: KerasTrainer_v0
-logdir: null
+          

--- a/jlab_datascience_toolkit/trainers/keras_trainer_v0.py
+++ b/jlab_datascience_toolkit/trainers/keras_trainer_v0.py
@@ -99,6 +99,11 @@ class Trainer(JDSTTrainer):
             )
 
     def fit(self, model, x=None, y=None, validation_data=None, sample_weight=None, logdir=None):
+        if "logdir" in self.configs:
+            if logdir is None:
+                logdir = self.configs["logdir"]
+            self.settings.pop("logdir")
+            
         model.model.compile(optimizer=self.optimizer, loss=self.loss)
         history = model.model.fit(
             x=x,

--- a/jlab_datascience_toolkit/utils/graph_driver_utils.py
+++ b/jlab_datascience_toolkit/utils/graph_driver_utils.py
@@ -40,7 +40,27 @@ class GraphRuntime():
 
         return module_dict
     
+    def get_args(self, data, module_dict, input):
+
+        split_input = input.split(sep=".")
+        if split_input[0] == "module":
+            data_in = module_dict[split_input[1]]
+        elif len(split_input) == 1:
+            data_in = data[input]
+        else:
+            raise KeyError(f"No input type: {split_input[0]}.")
+
+        return data_in
+
+    def convert_graph_lists_to_tuples(self, graph):
+        for edge in graph:
+            if isinstance(edge[0], list):
+                edge[0] = tuple(edge[0])
+            if isinstance(edge[2], list):
+                edge[2] = tuple(edge[2])
+
     def run_graph(self, graph, modules, config_kwargs_list):
+        self.convert_graph_lists_to_tuples(graph)
         graph_edges = self.tuples_to_edges(graph)
         data = self.get_distinct_data_dict(graph_edges)
         module_dict = self.get_module_dict(modules, config_kwargs_list)
@@ -55,9 +75,10 @@ class GraphRuntime():
             if edge.input is None:
                 fn_in = [] #Unpacks to 0 arguments
             elif isinstance(edge.input, str):
-                fn_in = [data[edge.input]] # Unpacks to 1 argument
+                data_in = self.get_args(data, module_dict, edge.input)
+                fn_in = [data_in] # Unpacks to 1 argument
             elif isinstance(edge.input, Iterable):
-                fn_in = [data[val] for val in edge.input]
+                fn_in = [self.get_args(data, module_dict, val) for val in edge.input]
             
             # Take advantage of list unpacking for arguments
             out = fn(*fn_in)
@@ -73,3 +94,6 @@ class GraphRuntime():
 
     def combine(self, *inputs):
         return inputs
+
+    def print(self, input):
+        print(input)

--- a/jlab_datascience_toolkit/workflows/graph_example_workflow_v0.py
+++ b/jlab_datascience_toolkit/workflows/graph_example_workflow_v0.py
@@ -22,7 +22,7 @@ register(id="SKLearnStandardScaler", entry_point=StandardScaler)
 @hydra.main(version_base=None, config_path="../cfgs/defaults", config_name="multiclass_graph_cfg")
 def main(configs: DictConfig):
 
-    configs = OmegaConf.to_container(configs)    # convert DictConfig ==> dict
+    configs = OmegaConf.to_container(configs, resolve=True)    # convert DictConfig ==> dict
 
     graph = configs["graph"]
     modules = configs["modules"]
@@ -30,10 +30,6 @@ def main(configs: DictConfig):
 
     graph_runtime = CustomGraphRuntime()
     data, module_dict = graph_runtime.run_graph(graph=graph, modules=modules, config_kwargs_list=config_kwargs_list)
-
-    # logdir = configs.get("logdir", None)
-    # if logdir is None:
-    #     logdir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
 
 if __name__ == "__main__":
     main()

--- a/jlab_datascience_toolkit/workflows/graph_example_workflow_v0.py
+++ b/jlab_datascience_toolkit/workflows/graph_example_workflow_v0.py
@@ -1,0 +1,39 @@
+import hydra
+from omegaconf import OmegaConf, DictConfig
+from sklearn.preprocessing import StandardScaler
+import jlab_datascience_toolkit
+from jlab_datascience_toolkit.utils.graph_driver_utils import GraphRuntime
+
+
+class CustomGraphRuntime(GraphRuntime):
+    def map_species(self, df):
+        classes_list = [(c, i) for i, c in enumerate(df["species"].unique().tolist())]
+        df["species_int"] = df["species"].map(dict(classes_list))
+        labels=[tup[1] for tup in classes_list]
+        target_names=[tup[0] for tup in classes_list]
+        return df, labels, target_names
+
+    def argmax(self, data):
+        return data.argmax(axis=1)
+
+from jlab_datascience_toolkit.utils.registration import register
+register(id="SKLearnStandardScaler", entry_point=StandardScaler)
+
+@hydra.main(version_base=None, config_path="../cfgs/defaults", config_name="multiclass_graph_cfg")
+def main(configs: DictConfig):
+
+    configs = OmegaConf.to_container(configs)    # convert DictConfig ==> dict
+
+    graph = configs["graph"]
+    modules = configs["modules"]
+    config_kwargs_list = configs["kwargs_list"]
+
+    graph_runtime = CustomGraphRuntime()
+    data, module_dict = graph_runtime.run_graph(graph=graph, modules=modules, config_kwargs_list=config_kwargs_list)
+
+    # logdir = configs.get("logdir", None)
+    # if logdir is None:
+    #     logdir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request covers the creation of a new graph driver example derived from the existing workflow example in the core. There are only two changes that would affect existing users in this PR:
- The` __init__.py` file for the toolkit now imports from most sub-packages (data_parsers, data_preps, models, trainers, and analyses)
  - This allows a single import of the toolkit to register all available modules. There is probably a nicer way to do this, but it works well for now.
- The graph driver has been updated with new features (printing, automatic list to tuple conversion, and modules as inputs). 
  - I don't believe the changes should cause any issues as all of the changes are new features. However, with new code comes the opportunity for unseen bugs, so this should be tested by people who are using the graph driver before we complete the PR. 

One thing to note: The graph driver does not currently allow for keyword-arguments which limits the example driver. Specifically, the trainer and analysis are not given a `logdir` argument, so they do not output any graphs. I think this issue will need to be dealt with separately; either we need to change the way the modules obtain the `logdir` (perhaps through their `__init__`?) or we need to figure out a solution for passing in keyword arguments. While the PR is in review, I may try to find a quick workaround, but it's likely these will need to be fixed in a separate issue/branch.